### PR TITLE
fix: prevent duplicate copy button in Moodle ≥4.4

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -22,11 +22,16 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+defined('MOODLE_INTERNAL') || die();
+
 use local_copy\core_hook_output;
 
-/**
- * Function local_copy_before_standard_html_head
- */
-function local_copy_before_standard_html_head() {
-    core_hook_output::before_standard_head_html_generation();
+if (version_compare($CFG->release, '4.4', '<')) {
+    /**
+     * Legacy callback for Moodle <4.4
+     */
+    function local_copy_before_standard_html_head(): void
+    {
+        core_hook_output::before_standard_head_html_generation();
+    }
 }


### PR DESCRIPTION
- Add version check in lib.php:
  • Register legacy callback only for Moodle <4.4
  • Rely solely on PSR-14 hook in db/hooks.php for Moodle ≥4.4
- Avoid double invocation of core_hook_output::before_standard_head_html_generation
- Preserve backward compatibility with Moodle <4.4
